### PR TITLE
Añadir migraciones de base de datos automáticas al Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM python:3.11-slim
 # Establecemos el directorio de trabajo dentro del contenedor
 WORKDIR /app
 
-# Copiamos solo los archivos necesarios para instalar dependencias primero 
+# Copiamos solo los archivos necesarios para instalar dependencias primero
 COPY requirements.txt .
 
 # Instalamos dependencias del sistema necesarias (apt) y luego las de Python
@@ -23,5 +23,11 @@ COPY . .
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 
-# Comando para ejecutar el servidor 
+# Ejecutamos las migraciones de la base de datos
+# Es importante que esto se haga después de copiar el resto del proyecto,
+# ya que las migraciones dependen del código de tu aplicación.
+RUN python manage.py makemigrations
+RUN python manage.py migrate
+
+# Comando para ejecutar el servidor
 CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]


### PR DESCRIPTION
Este PR añade la ejecución automática de las migraciones de Django en el Dockerfile.

El comando :
`RUN python manage.py migrate`
se han incluido para asegurar que la base de datos esté siempre actualizada al construir y desplegar el contenedor.

Cierra #27 