### PR TITLE
Habilita Deploy Continuo al mergear PRs a main

### DIFF
--- a/.github/workflows/django_cd.yml
+++ b/.github/workflows/django_cd.yml
@@ -1,8 +1,11 @@
 name: Entrega Continua
 
 on:
+  push:
+    branches:
+      - main
   release:
-    types: [published] 
+    types: [published]
 
 jobs:
   build_and_publish_docker:


### PR DESCRIPTION
close #33 

## Descripción
Esta PR modifica el workflow de Entrega Continua (`.github/workflows/cd.yml`) para que además de ejecutarse cuando se publica un release, también se dispare automáticamente al mergear Pull Requests hacia la rama `main`.

Con esto, aseguramos que la última versión estable del código desplegada en Render esté siempre actualizada sin necesidad de crear un release manual.

---

## Cambios realizados

- Se agregó el trigger `push` para la rama `main` junto con el trigger existente `release: published`.
- Se respetan los secretos configurados para Docker Hub y Render Deploy Hook.

---

## Cómo probarlo

1. Hacer merge de una PR a la rama `main`.
2. Verificar que el workflow de CD se ejecuta automáticamente.
3. Confirmar que la imagen Docker se construye y publica en Docker Hub con el tag esperado.
4. Confirmar que Render inicia el despliegue con la imagen publicada.
5. Verificar que la aplicación en https://eventhub-grupo4.onrender.com está accesible y funcionando.

